### PR TITLE
Fixed linux reader missing viper as args in calling sub-implementations.

### DIFF
--- a/internal/pkg/file/readers_linux.go
+++ b/internal/pkg/file/readers_linux.go
@@ -5,11 +5,15 @@ package file
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
+	"github.com/spf13/cast"
 	"github.com/spf13/viper"
 
+	"github.com/benz9527/idk-doc/internal/pkg/consts"
 	"github.com/benz9527/idk-doc/internal/pkg/intf"
 )
 
@@ -56,9 +60,9 @@ func NewConfigurationReader(viper *viper.Viper, fp string) intf.IConfigurationRe
 
 	switch strings.ToLower(ext) {
 	case "toml":
-		return newTomlReader(dir, filename, ext)
+		return newTomlReader(viper, dir, filename, ext)
 	case "yaml", "yml":
-		return newYamlReader(dir, filename, ext)
+		return newYamlReader(viper, dir, filename, ext)
 	default:
 		panic(fmt.Errorf("unknown and not support file extension [%s]", ext))
 	}


### PR DESCRIPTION
# 1. Descriptions
Currently, I usually under the win11 to develop the IDK, the GOOS often set as the windows and not change to linux to check linux code if correct also.  

# 2. How to fix
Added missing arg viper pointer to related called functions.